### PR TITLE
Replace usages of aptos/dist imports.

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -26,7 +26,7 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "aptos": "^1.3.10",
+    "aptos": "1.3.10",
     "big-integer": "^1.6.51",
     "elliptic": "^6.5.4",
     "json-stable-stringify": "^1.0.1",

--- a/typescript/src/aptosDataCache.ts
+++ b/typescript/src/aptosDataCache.ts
@@ -4,7 +4,6 @@ import { U128, U64 } from "./builtinTypes";
 import { AptosParserRepo, StructInfoType } from "./parserRepo";
 import { getTypeTagFullname, parseMoveStructTag, parseTypeTagOrThrow, StructTag, TypeTag } from "./typeTag";
 import stringify from "json-stable-stringify";
-import { DeleteResource, WriteResource } from "aptos/dist/generated";
 
 
 export interface ITable {
@@ -450,7 +449,7 @@ export class AptosResourceCache {
     if (txn.success && txn.hash !== '0x0') {
       for(const change of txn.changes) {
         if(change.type === 'write_resource' ) {
-          const write = change as WriteResource;
+          const write = change as Types.WriteResource;
           const typeTag = parseMoveStructTag(write.data.type);
           const resourceKey = this.getResourceKey(new HexString(write.address), typeTag);
           if (resourceKey in this.cachedResources) {
@@ -460,7 +459,7 @@ export class AptosResourceCache {
 
         }
         else if (change.type === 'delete_resource') {
-          const del = change as DeleteResource;
+          const del = change as Types.DeleteResource;
           const typeTag = parseMoveStructTag(del.resource);
           const resourceKey = this.getResourceKey(new HexString(del.address), typeTag);
           if (resourceKey in this.cachedResources) {

--- a/typescript/src/bcs.ts
+++ b/typescript/src/bcs.ts
@@ -1,5 +1,4 @@
-import { HexString } from "aptos";
-import { BCS } from "aptos/dist/transaction_builder";
+import { BCS, HexString } from "aptos";
 import { StructInfoType, U128, U64, U8 } from ".";
 import { u128, u64, u8 } from "./builtinFuncs";
 import { AtomicTypeTag, SimpleStructTag, StructTag, substituteTypeParams, TypeParamIdx, TypeTag, VectorTag } from "./typeTag";

--- a/typescript/src/nativeFuncs.ts
+++ b/typescript/src/nativeFuncs.ts
@@ -1,4 +1,4 @@
-import { HexString } from "aptos";
+import { BCS, HexString } from "aptos";
 import { AptosDataCache, IBox, ITable, AppType } from "./aptosDataCache";
 import { U128, U64, U8 } from "./builtinTypes";
 import { AtomicTypeTag, getTypeParamsString, getTypeTagFullname, parseTypeTagOrThrow, StructTag, TypeTag, VectorTag } from "./typeTag";
@@ -8,7 +8,6 @@ import bigInt from "big-integer";
 import * as elliptic from "elliptic";
 import { AptosParserRepo, FieldDeclType, parseStructProto, TypeParamDeclType } from "./parserRepo";
 import { strToU8, u64, u8str } from "./builtinFuncs";
-import { BCS } from "aptos/dist/transaction_builder";
 import { deserializeMoveValue, serializeMoveValue } from "./bcs";
 
 /*

--- a/typescript/src/typeTag.ts
+++ b/typescript/src/typeTag.ts
@@ -1,5 +1,4 @@
-import { HexString } from "aptos"
-import { MoveStructTag } from "aptos/dist/generated";
+import { HexString, Types } from "aptos"
 import { StructInfoType } from "./parserRepo";
 import { assert } from "./utils";
 
@@ -30,7 +29,7 @@ export class StructTag {
     return `${this.address.hex()}::${this.module}::${this.name}`;
   }
 
-  getAptosMoveTypeTag(): MoveStructTag {
+  getAptosMoveTypeTag(): Types.MoveStructTag {
     return this.getFullname();
     /*
     return {
@@ -252,7 +251,7 @@ export function parseTypeTagOrThrow(name: string): TypeTag {
   return tag;
 }
 
-export function parseMoveStructTag(moveTag: MoveStructTag): StructTag {
+export function parseMoveStructTag(moveTag: Types.MoveStructTag): StructTag {
   const result = parseTypeTagOrThrow(moveTag);
   if (!(result instanceof StructTag)) {
     throw new Error(`Expected a StructTag but instead received: ${moveTag}`);

--- a/typescript/yarn.lock
+++ b/typescript/yarn.lock
@@ -218,9 +218,9 @@ ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
-aptos@^1.3.10:
+aptos@1.3.10:
   version "1.3.10"
-  resolved "https://registry.npmjs.org/aptos/-/aptos-1.3.10.tgz"
+  resolved "https://registry.yarnpkg.com/aptos/-/aptos-1.3.10.tgz#a801e25456159485d27d0ff738c5e1fbd9fe073d"
   integrity sha512-a5DUuFR22gwxLBZqyXxIO656oA5pjHfON8Ll0sYdQGwUwnFYnbgJd9C7TFJok2/kGrRkM1rwyMdqsECVRPpqYA==
   dependencies:
     "@scure/bip39" "^1.1.0"


### PR DESCRIPTION
NOTE: There is still one left with TypeTagParser. That one doesn't have an easy fix unfortunately.

Also remove the semver for the `aptos` package