### PR TITLE
fix module err

### DIFF
--- a/src/ast_to_ts.rs
+++ b/src/ast_to_ts.rs
@@ -45,7 +45,6 @@ pub fn to_ts_string(v: &impl AstTsPrinter, c: &mut Context) -> Result<String, Di
         "import * as $ from \"@manahippo/move-to-ts\";".to_string(),
         "import {AptosDataCache, AptosParserRepo, DummyCache, AptosLocalCache} from \"@manahippo/move-to-ts\";".to_string(),
         "import {U8, U64, U128} from \"@manahippo/move-to-ts\";".to_string(),
-        "import {u8, u64, u128} from \"@manahippo/move-to-ts\";".to_string(),
         "import {TypeParamDeclType, FieldDeclType} from \"@manahippo/move-to-ts\";".to_string(),
         "import {AtomicTypeTag, StructTag, TypeTag, VectorTag, SimpleStructTag} from \"@manahippo/move-to-ts\";"
             .to_string(),

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -4,10 +4,9 @@
   "license": "MIT",
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig.json && tsc -p tsconfig.cjs.json",
-    "test": "node dist/esm/tests/index.js test"
+    "test": "node dist/cjs/tests/index.js test"
   },
   "sideEffects": false,
-  "type": "module",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",


### PR DESCRIPTION
const move_to_ts_1 = require("@manahippo/move-to-ts");
                     ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/jack/WorkFile/source/aptos-coin-list/typescript/node_modules/@manahippo/move-to-ts/dist/cjs/index.js from /Users/jack/WorkFile/source/aptos-coin-list/typescript/dist/cli.js not supported.
index.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead rename index.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in /Users/jack/WorkFile/source/aptos-coin-list/typescript/node_modules/@manahippo/move-to-ts/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).

    at Object.<anonymous> (/Users/jack/WorkFile/source/aptos-coin-list/typescript/dist/cli.js:36:22) {
  code: 'ERR_REQUIRE_ESM'
}